### PR TITLE
Add Persian timeseries table widget with Jalali support

### DIFF
--- a/ui-ngx/package.json
+++ b/ui-ngx/package.json
@@ -67,6 +67,7 @@
     "maplibre-gl": "^5.2.0",
     "marked": "~12.0.2",
     "moment": "^2.30.1",
+    "moment-jalaali": "^0.10.4",
     "moment-timezone": "^0.5.45",
     "ngx-clipboard": "^16.0.0",
     "ngx-daterangepicker-material": "^6.0.4",

--- a/ui-ngx/src/app/modules/home/components/widget/lib/persian-timeseries-table/persian-timeseries-table-widget.component.html
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/persian-timeseries-table/persian-timeseries-table-widget.component.html
@@ -1,0 +1,115 @@
+<div class="tb-table-widget tb-absolute-fill">
+  <div class="tb-absolute-fill flex flex-1 flex-col">
+    <mat-toolbar class="mat-mdc-table-toolbar" [class.!hidden]="!textSearchMode">
+      <div class="mat-toolbar-tools">
+        <button mat-icon-button
+                matTooltip="{{ 'action.search' | translate }}"
+                matTooltipPosition="above">
+          <mat-icon>search</mat-icon>
+        </button>
+        <mat-form-field class="flex-1">
+          <mat-label>&nbsp;</mat-label>
+          <input #searchInput matInput
+                 [formControl]="textSearch"
+                 placeholder="{{ 'widget.search-data' | translate }}"/>
+        </mat-form-field>
+        <button mat-icon-button (click)="exitFilterMode()"
+                matTooltip="{{ 'action.close' | translate }}"
+                matTooltipPosition="above">
+          <mat-icon>close</mat-icon>
+        </button>
+      </div>
+    </mat-toolbar>
+
+    <mat-tab-group [class.tb-headless]="sources.length === 1"
+                   class="flex-1"
+                   mat-stretch-tabs="false"
+                   [(selectedIndex)]="sourceIndex" (selectedIndexChange)="onSourceIndexChanged()">
+      <mat-tab *ngFor="let source of sources; trackBy: trackBySourcesIndex; let index = index;" [label]="getTabLabel(source)">
+        <ng-template [ngIf]="isActiveTab(index)">
+          <div class="table-container flex-1">
+            <table mat-table [dataSource]="source.timeseriesDatasource" [trackBy]="trackByRowTimestamp"
+                       matSort [matSortActive]="source.pageLink.sortOrder.property" [matSortDirection]="source.pageLink.sortDirection()" matSortDisableClear>
+              <ng-container *ngIf="showTimestamp" [matColumnDef]="'0'">
+                <mat-header-cell *matHeaderCellDef mat-sort-header>Timestamp</mat-header-cell>
+                <mat-cell *matCellDef="let row; let rowIndex = index"
+                          [innerHTML]="cellContent(source, null, 0, row, row[0], rowIndex) | async"
+                          [style]="cellStyle(source, null, 0, row, row[0], rowIndex) | async">
+                </mat-cell>
+              </ng-container>
+              <ng-container [matColumnDef]="h.index + ''" *ngFor="let h of source.header; trackBy: trackByColumnIndex;">
+                <mat-header-cell *matHeaderCellDef mat-sort-header [disabled]="!h.sortable"> {{ h.dataKey.label }} </mat-header-cell>
+                <mat-cell *matCellDef="let row; let rowIndex = index"
+                          [innerHTML]="cellContent(source, h, h.index, row, row[h.index], rowIndex) | async"
+                          [style]="cellStyle(source, h, h.index, row, row[h.index], rowIndex) | async">
+                </mat-cell>
+              </ng-container>
+              <ng-container matColumnDef="actions" [stickyEnd]="enableStickyAction">
+                <mat-header-cell *matHeaderCellDef>
+                  <ng-container *ngIf="source.timeseriesDatasource.countCellButtonAction">
+                    <div class="gt-md:!hidden" style="min-width: 40px;">
+                    </div>
+                    <div class="lt-lg:!hidden"
+                         [style.min-width]="(source.timeseriesDatasource.countCellButtonAction * 40) + 'px'">
+                    </div>
+                  </ng-container>
+                </mat-header-cell>
+                <mat-cell *matCellDef="let row; let rowIndex = index" [style]="rowStyle(source, row, rowIndex) | async">
+                  <ng-container *ngIf="source.timeseriesDatasource.countCellButtonAction">
+                    <div [class.lt-lg:!hidden]="showCellActionsMenu && source.timeseriesDatasource.countCellButtonAction !== 1" class="flex flex-row items-stretch justify-end"
+                         [style.min-width]="(source.timeseriesDatasource.countCellButtonAction * 40) + 'px'">
+                      <ng-container *ngFor="let actionDescriptor of row.actionCellButtons; trackBy: trackByActionCellDescriptionId">
+                        <span *ngIf="!actionDescriptor.icon" style="width: 40px;"></span>
+                        <button *ngIf="actionDescriptor.icon"
+                                class="tb-mat-40"
+                                mat-icon-button [disabled]="isLoading$ | async"
+                                matTooltip="{{ actionDescriptor.displayName }}"
+                                matTooltipPosition="above"
+                                (click)="onActionButtonClick($event, row, actionDescriptor)">
+                          <tb-icon>{{actionDescriptor.icon}}</tb-icon>
+                        </button>
+                      </ng-container>
+                    </div>
+                    <div [class.!hidden]="!showCellActionsMenu || source.timeseriesDatasource.countCellButtonAction === 1" class="gt-md:!hidden" *ngIf="row.hasActions">
+                      <button mat-icon-button
+                              class="tb-mat-40"
+                              (click)="$event.stopPropagation(); ctx.detectChanges();"
+                              [matMenuTriggerFor]="cellActionsMenu">
+                        <mat-icon class="material-icons">more_vert</mat-icon>
+                      </button>
+                      <mat-menu #cellActionsMenu="matMenu" xPosition="before">
+                        <ng-container *ngFor="let actionDescriptor of row.actionCellButtons; trackBy: trackByActionCellDescriptionId">
+                          <button mat-menu-item *ngIf="actionDescriptor.icon"
+                                  [disabled]="isLoading$ | async"
+                                  (click)="onActionButtonClick($event, row, actionDescriptor)">
+                            <tb-icon matMenuItemIcon>{{actionDescriptor.icon}}</tb-icon>
+                            <span>{{ actionDescriptor.displayName }}</span>
+                          </button>
+                        </ng-container>
+                      </mat-menu>
+                    </div>
+                  </ng-container>
+                </mat-cell>
+              </ng-container>
+              <mat-header-row *matHeaderRowDef="source.displayedColumns; sticky: enableStickyHeader"></mat-header-row>
+              <mat-row [class.tb-pointer]="hasRowAction"
+                       *matRowDef="let row; columns: source.displayedColumns; let rowIndex = index"
+                       [style]="rowStyle(source, row, rowIndex) | async"
+                       (click)="onRowClick($event, row)"></mat-row>
+            </table>
+            <span [class.!hidden]="(source.timeseriesDatasource.isEmpty() | async) === false"
+                  class="no-data-found flex items-center justify-center">{{ noDataDisplayMessageText }}</span>
+          </div>
+          <mat-divider *ngIf="displayPagination"></mat-divider>
+          <mat-paginator *ngIf="displayPagination"
+                         [length]="source.timeseriesDatasource.total() | async"
+                         [pageIndex]="source.pageLink.page"
+                         [pageSize]="source.pageLink.pageSize"
+                         [pageSizeOptions]="pageSizeOptions"
+                         [hidePageSize]="hidePageSize"
+                         showFirstLastButtons></mat-paginator>
+        </ng-template>
+      </mat-tab>
+    </mat-tab-group>
+  </div>
+</div>

--- a/ui-ngx/src/app/modules/home/components/widget/lib/persian-timeseries-table/persian-timeseries-table-widget.component.scss
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/persian-timeseries-table/persian-timeseries-table-widget.component.scss
@@ -1,0 +1,35 @@
+:host {
+  width: 100%;
+  height: 100%;
+  display: block;
+  .tb-table-widget {
+    mat-footer-row, mat-row {
+      height: 38px;
+    }
+    mat-header-row {
+      height: 40px;
+    }
+    mat-toolbar {
+      z-index: 10;
+    }
+    span.no-data-found {
+      height: calc(100% - 44px);
+    }
+  }
+}
+
+:host ::ng-deep {
+  .tb-table-widget {
+    .mat-mdc-tab-group {
+      height: 100%;
+      overflow: hidden;
+    }
+    .mat-mdc-tab-body-wrapper {
+      height: 100%;
+    }
+    .mat-mdc-tab-body-content {
+      display: flex;
+      flex-direction: column;
+    }
+  }
+}

--- a/ui-ngx/src/app/modules/home/components/widget/lib/persian-timeseries-table/persian-timeseries-table-widget.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/persian-timeseries-table/persian-timeseries-table-widget.component.ts
@@ -1,0 +1,1085 @@
+import {
+  AfterViewInit,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  Injector,
+  Input,
+  NgZone,
+  OnDestroy,
+  OnInit,
+  QueryList,
+  StaticProvider,
+  ViewChild,
+  ViewChildren,
+  ViewContainerRef
+} from '@angular/core';
+import { PageComponent } from '@shared/components/page.component';
+import { Store } from '@ngrx/store';
+import { AppState } from '@core/core.state';
+import { WidgetAction, WidgetContext } from '@home/models/widget-component.models';
+import {
+  DataKey,
+  Datasource,
+  DatasourceData,
+  DatasourceType,
+  WidgetActionDescriptor,
+  WidgetConfig
+} from '@shared/models/widget.models';
+import { UtilsService } from '@core/services/utils.service';
+import { TranslateService } from '@ngx-translate/core';
+import {
+  formattedDataFormDatasourceData,
+  hashCode,
+  isDefined,
+  isDefinedAndNotNull,
+  isObject,
+  isUndefined
+} from '@core/utils';
+import cssjs from '@core/css/css';
+import { PageLink } from '@shared/models/page/page-link';
+import { Direction, SortOrder, sortOrderFromString } from '@shared/models/page/sort-order';
+import { CollectionViewer, DataSource } from '@angular/cdk/collections';
+import { BehaviorSubject, fromEvent, merge, Observable, of, Subject, Subscription } from 'rxjs';
+import { emptyPageData, PageData } from '@shared/models/page/page-data';
+import {
+  catchError,
+  debounceTime,
+  distinctUntilChanged,
+  map,
+  skip,
+  startWith,
+  switchMap,
+  takeUntil,
+  tap
+} from 'rxjs/operators';
+import { MatPaginator } from '@angular/material/paginator';
+import { MatSort } from '@angular/material/sort';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import {
+  CellContentInfo,
+  CellStyleInfo,
+  checkHasActions,
+  constructTableCssString,
+  DisplayColumn,
+  getCellContentFunctionInfo,
+  getCellStyleInfo,
+  getColumnDefaultVisibility,
+  getColumnSelectionAvailability,
+  getRowStyleInfo,
+  getTableCellButtonActions,
+  isValidPageStepCount,
+  isValidPageStepIncrement,
+  noDataMessage,
+  prepareTableCellButtonActions,
+  RowStyleInfo,
+  TableCellButtonActionDescriptor,
+  TableWidgetDataKeySettings,
+  TableWidgetSettings
+} from '@home/components/widget/lib/table-widget.models';
+import { Overlay, OverlayConfig, OverlayRef } from '@angular/cdk/overlay';
+import { SubscriptionEntityInfo } from '@core/api/widget-api.models';
+import { DatePipe } from '@angular/common';
+import { coerceBooleanProperty } from '@angular/cdk/coercion';
+import { hidePageSizePixelValue } from '@shared/models/constants';
+import {
+  DISPLAY_COLUMNS_PANEL_DATA,
+  DisplayColumnsPanelComponent
+} from '@home/components/widget/lib/display-columns-panel.component';
+import { ComponentPortal } from '@angular/cdk/portal';
+import { FormBuilder } from '@angular/forms';
+import { DEFAULT_OVERLAY_POSITIONS } from '@shared/models/overlay.models';
+import { DateFormatSettings, ValueFormatProcessor } from '@shared/models/widget-settings.models';
+
+import moment from 'moment-jalaali';
+
+export interface PersianTimeseriesTableWidgetSettings extends TableWidgetSettings {
+  showTimestamp: boolean;
+  showMilliseconds: boolean;
+  hideEmptyLines: boolean;
+  dateFormat: DateFormatSettings;
+  useJalaliDate: boolean; // اضافه کردن تنظیم جدید برای تاریخ شمسی یا میلادی
+}
+
+interface TimeseriesWidgetLatestDataKeySettings extends TableWidgetDataKeySettings {
+  show: boolean;
+  order: number;
+}
+
+interface TimeseriesRow {
+  actionCellButtons?: TableCellButtonActionDescriptor[];
+  hasActions?: boolean;
+  [col: number]: any;
+  formattedTs: string;
+}
+
+interface TimeseriesHeader {
+  index: number;
+  dataKey: DataKey;
+  sortable: boolean;
+  show: boolean;
+  columnDefaultVisibility?: boolean;
+  columnSelectionAvailability?: boolean;
+  styleInfo: Observable<CellStyleInfo>;
+  contentInfo: CellContentInfo;
+  order?: number;
+}
+
+interface TimeseriesTableSource {
+  keyStartIndex: number;
+  keyEndIndex: number;
+  latestKeyStartIndex: number;
+  latestKeyEndIndex: number;
+  datasource: Datasource;
+  rawData: Array<DatasourceData>;
+  latestRawData: Array<DatasourceData>;
+  data: TimeseriesRow[];
+  pageLink: PageLink;
+  displayedColumns: string[];
+  timeseriesDatasource: TimeseriesDatasource;
+  header: TimeseriesHeader[];
+  rowDataTemplate: {[key: string]: any};
+}
+
+@Component({
+  selector: 'persian-timeseries-table-widget',
+  templateUrl: './persian-timeseries-table-widget.component.html',
+  styleUrls: ['./persian-timeseries-table-widget.component.scss', '../table-widget.scss']
+})
+export class PersianTimeseriesTableWidgetComponent extends PageComponent implements OnInit, AfterViewInit, OnDestroy {
+
+  @Input()
+  ctx: WidgetContext;
+
+  @ViewChild('searchInput') searchInputField: ElementRef;
+  @ViewChildren(MatPaginator) paginators: QueryList<MatPaginator>;
+  @ViewChildren(MatSort) sorts: QueryList<MatSort>;
+
+  textSearch = this.fb.control('', {nonNullable: true});
+
+  public displayPagination = true;
+  public enableStickyHeader = true;
+  public enableStickyAction = true;
+  public showCellActionsMenu = true;
+  public pageSizeOptions = [];
+  public textSearchMode = false;
+  public hidePageSize = false;
+  public sources: TimeseriesTableSource[];
+  public sourceIndex: number;
+  public noDataDisplayMessageText: string;
+  public hasRowAction: boolean;
+  private setCellButtonAction: boolean;
+
+  private cellContentCache: Array<any> = [];
+  private cellStyleCache: Array<any> = [];
+  private rowStyleCache: Array<any> = [];
+
+  // I changed this parameter from private to public so that in template I can access it!
+  settings: PersianTimeseriesTableWidgetSettings;
+  private widgetConfig: WidgetConfig;
+  private data: Array<DatasourceData>;
+  private latestData: Array<DatasourceData>;
+  private datasources: Array<Datasource>;
+
+  private defaultPageSize;
+  private defaultSortOrder = '-0';
+  private hideEmptyLines = false;
+  public showTimestamp = true;
+  private useEntityLabel = false;
+  private dateFormatFilter: string;
+
+  private displayedColumns: Array<DisplayColumn[]> = [];
+
+  private rowStylesInfo: Observable<RowStyleInfo>;
+
+  private subscriptions: Subscription[] = [];
+  private widgetTimewindowChanged$: Subscription;
+  private widgetResize$: ResizeObserver;
+  private destroy$ = new Subject<void>();
+
+  private searchAction: WidgetAction = {
+    name: 'action.search',
+    show: true,
+    icon: 'search',
+    onAction: () => {
+      this.enterFilterMode();
+    }
+  };
+
+  private columnDisplayAction: WidgetAction = {
+    name: 'entity.columns-to-display',
+    show: true,
+    icon: 'view_column',
+    onAction: ($event) => {
+      this.editColumnsToDisplay($event);
+    }
+  };
+
+  constructor(protected store: Store<AppState>,
+              private elementRef: ElementRef,
+              private overlay: Overlay,
+              private viewContainerRef: ViewContainerRef,
+              private utils: UtilsService,
+              private translate: TranslateService,
+              private domSanitizer: DomSanitizer,
+              private datePipe: DatePipe,
+              private cd: ChangeDetectorRef,
+              private fb: FormBuilder,
+              private zone: NgZone) {
+    super(store);
+  }
+
+  ngOnInit(): void {
+    this.ctx.$scope.timeseriesTableWidget = this;
+    this.settings = this.ctx.settings;
+    this.widgetConfig = this.ctx.widgetConfig;
+    this.data = this.ctx.data;
+    this.latestData = this.ctx.latestData;
+    this.datasources = this.ctx.datasources;
+    this.initialize();
+    this.ctx.updateWidgetParams();
+
+    if (this.displayPagination) {
+      this.widgetTimewindowChanged$ = this.ctx.defaultSubscription.widgetTimewindowChanged$.subscribe(
+        () => {
+          this.sources.forEach((source) => {
+            if (this.displayPagination) {
+              source.pageLink.page = 0;
+            }
+          });
+        }
+      );
+      this.widgetResize$ = new ResizeObserver(() => {
+        this.zone.run(() => {
+          const showHidePageSize = this.elementRef.nativeElement.offsetWidth < hidePageSizePixelValue;
+          if (showHidePageSize !== this.hidePageSize) {
+            this.hidePageSize = showHidePageSize;
+            this.cd.markForCheck();
+          }
+        });
+      });
+      this.widgetResize$.observe(this.elementRef.nativeElement);
+    }
+  }
+
+  ngOnDestroy(): void {
+    if (this.widgetTimewindowChanged$) {
+      this.widgetTimewindowChanged$.unsubscribe();
+      this.widgetTimewindowChanged$ = null;
+    }
+    if (this.widgetResize$) {
+      this.widgetResize$.disconnect();
+    }
+  }
+
+  ngAfterViewInit(): void {
+    this.textSearch.valueChanges.pipe(
+      debounceTime(150),
+      startWith(''),
+      distinctUntilChanged((a: string, b: string) => a.trim() === b.trim()),
+      skip(1),
+      takeUntil(this.destroy$)
+    ).subscribe((textSearch) => {
+      this.sources.forEach((source) => {
+        source.pageLink.textSearch = textSearch.trim();
+        if (this.displayPagination) {
+          source.pageLink.page = 0;
+        }
+      });
+      this.loadCurrentSourceRow();
+      this.ctx.detectChanges();
+    });
+
+    this.sorts.changes.pipe(takeUntil(this.destroy$)).subscribe(() => {
+      this.initSubscriptionsToSortAndPaginator();
+    });
+
+    this.initSubscriptionsToSortAndPaginator();
+  }
+
+  public onDataUpdated() {
+    this.updateCurrentSourceData();
+    this.clearCache();
+    this.ctx.detectChanges();
+  }
+
+  public onLatestDataUpdated() {
+    this.updateCurrentSourceLatestData();
+    this.clearCache();
+    this.ctx.detectChanges();
+  }
+
+  public onEditModeChanged() {
+    if (this.textSearchMode) {
+      this.ctx.hideTitlePanel = !this.ctx.isEdit;
+      this.ctx.detectChanges(true);
+    }
+  }
+
+  private initialize() {
+    this.ctx.widgetActions = [this.searchAction, this.columnDisplayAction];
+
+    this.setCellButtonAction = !!this.ctx.actionsApi.getActionDescriptors('actionCellButton').length;
+    this.hasRowAction = !!this.ctx.actionsApi.getActionDescriptors('rowClick').length;
+
+    this.searchAction.show = isDefined(this.settings.enableSearch) ? this.settings.enableSearch : true;
+    this.columnDisplayAction.show = isDefined(this.settings.enableSelectColumnDisplay) ? this.settings.enableSelectColumnDisplay : true;
+    this.displayPagination = isDefined(this.settings.displayPagination) ? this.settings.displayPagination : true;
+    this.enableStickyHeader = isDefined(this.settings.enableStickyHeader) ? this.settings.enableStickyHeader : true;
+    this.enableStickyAction = isDefined(this.settings.enableStickyAction) ? this.settings.enableStickyAction : true;
+    this.showCellActionsMenu = isDefined(this.settings.showCellActionsMenu) ? this.settings.showCellActionsMenu : true;
+    this.hideEmptyLines = isDefined(this.settings.hideEmptyLines) ? this.settings.hideEmptyLines : false;
+    this.useEntityLabel = isDefined(this.widgetConfig.settings.useEntityLabel) ? this.widgetConfig.settings.useEntityLabel : false;
+    this.showTimestamp = this.settings.showTimestamp !== false;
+    // For backward compatibility
+    if (isDefined(this.settings?.showMilliseconds) && this.settings?.showMilliseconds) {
+      this.dateFormatFilter = 'yyyy-MM-dd HH:mm:ss.SSS';
+    } else {
+      this.dateFormatFilter = isDefined(this.settings.dateFormat?.format) ? this.settings.dateFormat?.format : 'yyyy-MM-dd HH:mm:ss';
+    }
+
+    // تعیین مقدار پیش‌فرض برای تنظیمات مربوط به نمایش تاریخ جلالی
+    this.settings.useJalaliDate = isDefined(this.settings.useJalaliDate) ? this.settings.useJalaliDate : true;
+
+    this.rowStylesInfo = getRowStyleInfo(this.ctx, this.settings, 'rowData, ctx');
+
+    const pageSize = this.settings.defaultPageSize;
+    let pageStepIncrement = isValidPageStepIncrement(this.settings.pageStepIncrement) ? this.settings.pageStepIncrement : null;
+    let pageStepCount = isValidPageStepCount(this.settings.pageStepCount) ? this.settings.pageStepCount : null;
+
+    if (Number.isInteger(pageSize) && pageSize > 0) {
+      this.defaultPageSize = pageSize;
+    }
+
+    if (!this.defaultPageSize) {
+      this.defaultPageSize = pageStepIncrement ?? 10;
+    }
+
+    if (!isDefinedAndNotNull(pageStepIncrement) || !isDefinedAndNotNull(pageStepCount)) {
+      pageStepIncrement = this.defaultPageSize;
+      pageStepCount = 3;
+    }
+
+    for (let i = 1; i <= pageStepCount; i++) {
+      this.pageSizeOptions.push(pageStepIncrement * i);
+    }
+
+    this.noDataDisplayMessageText =
+      noDataMessage(this.widgetConfig.noDataDisplayMessage, 'widget.no-data-found', this.utils, this.translate);
+
+    let cssString = constructTableCssString(this.widgetConfig);
+
+    const origBackgroundColor = this.widgetConfig.backgroundColor || 'rgb(255, 255, 255)';
+    cssString += '.tb-table-widget mat-toolbar.mat-mdc-table-toolbar:not([color=primary]) {\n' +
+    'background-color: ' + origBackgroundColor + ' !important;\n' +
+    '}\n';
+
+    const cssParser = new cssjs();
+    cssParser.testMode = false;
+    const namespace = 'ts-table-' + hashCode(cssString);
+    cssParser.cssPreviewNamespace = namespace;
+    cssParser.createStyleElement(namespace, cssString);
+    $(this.elementRef.nativeElement).addClass(namespace);
+    this.updateDatasources();
+  }
+
+  public getTabLabel(source: TimeseriesTableSource){
+    if (this.useEntityLabel) {
+      return source.datasource.entityLabel || source.datasource.entityName;
+    } else {
+      return source.datasource.entityName;
+    }
+  }
+
+  private updateDatasources() {
+    this.sources = [];
+    this.sourceIndex = 0;
+    let keyOffset = 0;
+    let latestKeyOffset = 0;
+    const pageSize = this.displayPagination ? this.defaultPageSize : Number.POSITIVE_INFINITY;
+    if (this.datasources) {
+      for (const datasource of this.datasources) {
+        const sortOrder: SortOrder = sortOrderFromString(this.defaultSortOrder);
+        const source = {} as TimeseriesTableSource;
+        source.header = this.prepareHeader(datasource);
+        source.keyStartIndex = keyOffset;
+        keyOffset += datasource.dataKeys.length;
+        source.keyEndIndex = keyOffset;
+        source.latestKeyStartIndex = latestKeyOffset;
+        latestKeyOffset += datasource.latestDataKeys ? datasource.latestDataKeys.length : 0;
+        source.latestKeyEndIndex = latestKeyOffset;
+        source.datasource = datasource;
+        source.data = [];
+        source.rawData = [];
+        source.displayedColumns = [];
+        source.pageLink = new PageLink(pageSize, 0, null, sortOrder);
+        source.rowDataTemplate = {};
+        source.rowDataTemplate.Timestamp = null;
+        if (this.showTimestamp) {
+          source.displayedColumns.push('0');
+        }
+        source.header.forEach(header => {
+          const dataKey = header.dataKey;
+          if (header.show) {
+            source.displayedColumns.push(header.index + '');
+          }
+          source.rowDataTemplate[dataKey.label] = null;
+        });
+        if (this.setCellButtonAction) {
+          source.displayedColumns.push('actions');
+        }
+        const tsDatasource = new TimeseriesDatasource(source, this.hideEmptyLines, this.dateFormatFilter, this.datePipe, this.ctx);
+        tsDatasource.allDataUpdated(this.data, this.latestData);
+        this.sources.push(source);
+      }
+    }
+    if (this.sources.length) {
+      this.sources.forEach((source, index) => {
+        this.prepareDisplayedColumn(index);
+        source.displayedColumns = this.displayedColumns[index].filter(value => value.display).map(value => value.def);
+      });
+    }
+    this.updateActiveEntityInfo();
+  }
+
+  private editColumnsToDisplay($event: Event) {
+    if ($event) {
+      $event.stopPropagation();
+    }
+    if (this.sources.length) {
+      const target = $event.target || $event.currentTarget;
+      const config = new OverlayConfig({
+        panelClass: 'tb-panel-container',
+        backdropClass: 'cdk-overlay-transparent-backdrop',
+        hasBackdrop: true,
+        height: 'fit-content',
+        maxHeight: '75vh'
+      });
+      config.positionStrategy = this.overlay.position()
+        .flexibleConnectedTo(target as HTMLElement)
+        .withPositions(DEFAULT_OVERLAY_POSITIONS);
+
+      const overlayRef = this.overlay.create(config);
+      overlayRef.backdropClick().subscribe(() => {
+        overlayRef.dispose();
+      });
+
+      const source = this.sources[this.sourceIndex];
+
+      const providers: StaticProvider[] = [
+        {
+          provide: DISPLAY_COLUMNS_PANEL_DATA,
+          useValue: {
+            columns: this.displayedColumns[this.sourceIndex],
+            columnsUpdated: (newColumns) => {
+              source.displayedColumns = newColumns.filter(value => value.display).map(value => value.def);
+              this.clearCache();
+            }
+          }
+        },
+        {
+          provide: OverlayRef,
+          useValue: overlayRef
+        }
+      ];
+
+      const injector = Injector.create({parent: this.viewContainerRef.injector, providers});
+      const componentRef = overlayRef.attach(new ComponentPortal(DisplayColumnsPanelComponent,
+        this.viewContainerRef, injector));
+
+      const resizeWindows$ = fromEvent(window, 'resize').subscribe(() => {
+        overlayRef.updatePosition();
+      });
+      componentRef.onDestroy(() => {
+        resizeWindows$.unsubscribe();
+      });
+
+      this.ctx.detectChanges();
+    }
+  }
+
+  private prepareDisplayedColumn(index: number) {
+    if (!this.displayedColumns[index]) {
+      this.displayedColumns[index] = this.sources[index].displayedColumns.map(value => {
+        let title = '';
+        const header = this.sources[index].header.find(column => column.index.toString() === value);
+        if (value === '0') {
+          title = 'Timestamp';
+        } else if (value === 'actions') {
+          title = 'Actions';
+        } else {
+          title = header.dataKey.label;
+        }
+        return {
+          title,
+          def: value,
+          display: header?.columnDefaultVisibility ?? true,
+          selectable: header?.columnSelectionAvailability ?? true
+        };
+      });
+    }
+  }
+
+  private prepareHeader(datasource: Datasource): TimeseriesHeader[] {
+    const dataKeys = datasource.dataKeys;
+    const latestDataKeys = datasource.latestDataKeys;
+    let header: TimeseriesHeader[] = [];
+    dataKeys.forEach((dataKey, index) => {
+      const keySettings: TableWidgetDataKeySettings = dataKey.settings;
+      const sortable = !keySettings.disableSorting && !dataKey.usePostProcessing;
+      const styleInfo = getCellStyleInfo(this.ctx, keySettings, 'value, rowData, ctx');
+      const contentFunctionInfo = getCellContentFunctionInfo(this.ctx, keySettings, 'value, rowData, ctx');
+      const columnDefaultVisibility = getColumnDefaultVisibility(keySettings, this.ctx);
+      const columnSelectionAvailability = getColumnSelectionAvailability(keySettings);
+      const decimals = (dataKey.decimals || dataKey.decimals === 0) ? dataKey.decimals : this.ctx.widgetConfig.decimals;
+      const units = dataKey.units || this.ctx.widgetConfig.units;
+      const valueFormat = ValueFormatProcessor.fromSettings(this.ctx.$injector, {units, decimals, showZeroDecimals: true});
+      const contentInfo: CellContentInfo = {
+        contentFunction: contentFunctionInfo,
+        valueFormat
+      };
+      header.push({
+        index: index + 1,
+        dataKey,
+        sortable,
+        styleInfo,
+        contentInfo,
+        show: true,
+        columnDefaultVisibility,
+        columnSelectionAvailability,
+        order: index + 2
+      });
+    });
+    if (latestDataKeys) {
+      latestDataKeys.forEach((dataKey, latestIndex) => {
+        const index = dataKeys.length + latestIndex;
+        const keySettings: TimeseriesWidgetLatestDataKeySettings = dataKey.settings;
+        const sortable = !keySettings.disableSorting && !dataKey.usePostProcessing;
+        const styleInfo = getCellStyleInfo(this.ctx, keySettings, 'value, rowData, ctx');
+        const contentFunctionInfo = getCellContentFunctionInfo(this.ctx, keySettings, 'value, rowData, ctx');
+        const columnDefaultVisibility = getColumnDefaultVisibility(keySettings, this.ctx);
+        const columnSelectionAvailability = getColumnSelectionAvailability(keySettings);
+        const decimals = (dataKey.decimals || dataKey.decimals === 0) ? dataKey.decimals : this.ctx.widgetConfig.decimals;
+        const units = dataKey.units || this.ctx.widgetConfig.units;
+        const valueFormat = ValueFormatProcessor.fromSettings(this.ctx.$injector, {units, decimals, showZeroDecimals: true});
+        const contentInfo: CellContentInfo = {
+          contentFunction: contentFunctionInfo,
+          valueFormat
+        };
+        header.push({
+          index: index + 1,
+          dataKey,
+          sortable,
+          styleInfo,
+          contentInfo,
+          show: isDefinedAndNotNull(keySettings.show) ? keySettings.show : true,
+          columnDefaultVisibility,
+          columnSelectionAvailability,
+          order: isDefinedAndNotNull(keySettings.order) ? keySettings.order : (index + 2)
+        });
+      });
+    }
+    header = header.sort((a, b) => a.order - b.order);
+    return header;
+  }
+
+  private updateActiveEntityInfo() {
+    const source = this.sources[this.sourceIndex];
+    let activeEntityInfo: SubscriptionEntityInfo = null;
+    if (source) {
+      const datasource = source.datasource;
+      if (datasource.type === DatasourceType.entity &&
+        datasource.entityType && datasource.entityId) {
+        activeEntityInfo = {
+          entityId: {
+            entityType: datasource.entityType,
+            id: datasource.entityId
+          },
+          entityName: datasource.entityName,
+          entityLabel: datasource.entityLabel,
+          entityDescription: datasource.entityDescription
+        };
+      }
+    }
+    this.ctx.activeEntityInfo = activeEntityInfo;
+  }
+
+  private initSubscriptionsToSortAndPaginator() {
+    this.subscriptions.forEach(subscription => subscription.unsubscribe());
+    this.sorts.forEach((sort, index) => {
+      let paginator = null;
+      const observables = [sort.sortChange];
+      if (this.displayPagination) {
+        paginator = this.paginators.toArray()[index];
+        this.subscriptions.push(
+          sort.sortChange.subscribe(() => paginator.pageIndex = 0)
+        );
+        observables.push(paginator.page);
+      }
+      this.updateData(sort, paginator);
+      this.subscriptions.push(merge(...observables).subscribe(() => this.updateData(sort, paginator)));
+    });
+  }
+
+  onSourceIndexChanged() {
+    this.updateCurrentSourceAllData();
+    this.updateActiveEntityInfo();
+    this.clearCache();
+  }
+
+  private enterFilterMode() {
+    this.textSearchMode = true;
+    this.ctx.hideTitlePanel = true;
+    this.ctx.detectChanges(true);
+    setTimeout(() => {
+      this.searchInputField.nativeElement.focus();
+      this.searchInputField.nativeElement.setSelectionRange(0, 0);
+    }, 10);
+  }
+
+  exitFilterMode() {
+    this.textSearchMode = false;
+    this.textSearch.reset();
+    this.loadCurrentSourceRow();
+    this.ctx.hideTitlePanel = false;
+    this.ctx.detectChanges(true);
+  }
+
+  private updateData(sort: MatSort, paginator: MatPaginator) {
+    const source = this.sources[this.sourceIndex];
+    if (this.displayPagination) {
+      source.pageLink.page = paginator.pageIndex;
+      source.pageLink.pageSize = paginator.pageSize;
+    } else {
+      source.pageLink.page = 0;
+    }
+    source.pageLink.sortOrder.property = sort.active;
+    source.pageLink.sortOrder.direction = Direction[sort.direction.toUpperCase()];
+    source.timeseriesDatasource.loadRows();
+    this.clearCache();
+    this.ctx.detectChanges();
+  }
+
+  public trackByColumnIndex(index, header: TimeseriesHeader) {
+    return header.index;
+  }
+
+  public trackByRowTimestamp(index: number) {
+    return index;
+  }
+
+  public trackByActionCellDescriptionId(index: number, action: WidgetActionDescriptor) {
+    return action.id;
+  }
+
+  public trackBySourcesIndex(index: number, source: TimeseriesTableSource) {
+    return source.datasource.entityId;
+  }
+
+  public rowStyle(source: TimeseriesTableSource, row: TimeseriesRow, index: number): Observable<any> {
+    let style$: Observable<any>;
+    const res = this.rowStyleCache[index];
+    if (!res) {
+      style$ = this.rowStylesInfo.pipe(
+        map(styleInfo => {
+          if (styleInfo.useRowStyleFunction && styleInfo.rowStyleFunction) {
+            const rowData = source.rowDataTemplate;
+            rowData.Timestamp = row[0];
+            source.header.forEach((headerInfo) => {
+              rowData[headerInfo.dataKey.label] = row[headerInfo.index];
+            });
+            const style = styleInfo.rowStyleFunction.execute(rowData, this.ctx);
+            if (!isObject(style)) {
+              throw new TypeError(`${style === null ? 'null' : typeof style} instead of style object`);
+            }
+            if (Array.isArray(style)) {
+              throw new TypeError(`Array instead of style object`);
+            }
+            return style;
+          } else {
+            return {};
+          }
+        }),
+        catchError(e => {
+          console.warn(`Row style function in widget ` +
+            `'${this.ctx.widgetConfig.title}' returns '${e}'. Please check your row style function.`);
+          return of({});
+        })
+      );
+      style$ = style$.pipe(
+        tap((style) => {
+          this.rowStyleCache[index] = style;
+        })
+      );
+    } else {
+      style$ = of(res);
+    }
+    return style$;
+  }
+
+  public cellStyle(source: TimeseriesTableSource, header: TimeseriesHeader,
+                   index: number, row: TimeseriesRow, value: any, rowIndex: number): Observable<any> {
+    let style$: Observable<any>;
+    const cacheIndex = rowIndex * (source.header.length + 1) + index;
+    const res = this.cellStyleCache[cacheIndex];
+    if (!res) {
+      if (index > 0) {
+        style$ = header.styleInfo.pipe(
+          map(styleInfo => {
+            if (styleInfo.useCellStyleFunction && styleInfo.cellStyleFunction) {
+              const rowData = source.rowDataTemplate;
+              rowData.Timestamp = row[0];
+              source.header.forEach((headerInfo) => {
+                rowData[headerInfo.dataKey.label] = row[headerInfo.index];
+              });
+              const style = styleInfo.cellStyleFunction.execute(value, rowData, this.ctx);
+              if (!isObject(style)) {
+                throw new TypeError(`${style === null ? 'null' : typeof style} instead of style object`);
+              }
+              if (Array.isArray(style)) {
+                throw new TypeError(`Array instead of style object`);
+              }
+              return style;
+            } else {
+              return {};
+            }
+          }),
+          catchError(e => {
+            console.warn(`Cell style function for data key '${source.header[index - 1].dataKey.label}' in widget ` +
+              `'${this.ctx.widgetConfig.title}' returns '${e}'. Please check your cell style function.`);
+            return of({});
+          })
+        );
+      } else {
+        style$ = of({});
+      }
+      style$ = style$.pipe(
+        tap((style) => {
+          this.cellStyleCache[cacheIndex] = style;
+        })
+      );
+    } else {
+      style$ = of(res);
+    }
+    return style$;
+  }
+
+  public cellContent(source: TimeseriesTableSource, header: TimeseriesHeader,
+                     index: number, row: TimeseriesRow, value: any, rowIndex: number): Observable<SafeHtml> {
+    let content$: Observable<SafeHtml>;
+    const cacheIndex = rowIndex * (source.header.length + 1) + index ;
+    const res = this.cellContentCache[cacheIndex];
+    if (isUndefined(res)) {
+      if (index === 0) {
+        content$ = of(row.formattedTs);
+      } else {
+        content$ = header.contentInfo.contentFunction.pipe(
+          map((contentFunction) => {
+            let content: any;
+            if (contentFunction.useCellContentFunction && contentFunction.cellContentFunction) {
+              try {
+                const rowData = source.rowDataTemplate;
+                rowData.Timestamp = row[0];
+                source.header.forEach((headerInfo) => {
+                  rowData[headerInfo.dataKey.label] = row[headerInfo.index];
+                });
+                content = contentFunction.cellContentFunction.execute(value, rowData, this.ctx);
+              } catch (e) {
+                content = '' + value;
+              }
+            } else {
+              content = header.contentInfo.valueFormat.format(value);
+            }
+            if (isDefined(content)) {
+              content = this.utils.customTranslation(content, content);
+              switch (typeof content) {
+                case 'string':
+                  content = this.domSanitizer.bypassSecurityTrustHtml(content);
+                  break;
+              }
+            }
+            return content;
+          })
+        );
+      }
+      content$ = content$.pipe(
+        tap((content) => {
+          this.cellContentCache[cacheIndex] = content;
+        })
+      );
+    } else {
+      content$ = of(res);
+    }
+    return content$;
+  }
+
+  public onRowClick($event: Event, row: TimeseriesRow) {
+    const descriptors = this.ctx.actionsApi.getActionDescriptors('rowClick');
+    if (descriptors.length) {
+      if ($event) {
+        $event.stopPropagation();
+      }
+      let entityId;
+      let entityName;
+      let entityLabel;
+      if (this.ctx.activeEntityInfo) {
+        entityId = this.ctx.activeEntityInfo.entityId;
+        entityName = this.ctx.activeEntityInfo.entityName;
+        entityLabel = this.ctx.activeEntityInfo.entityLabel;
+      }
+      this.ctx.actionsApi.handleWidgetAction($event, descriptors[0], entityId, entityName, row, entityLabel);
+    }
+  }
+
+  public onActionButtonClick($event: Event, row: TimeseriesRow, actionDescriptor: WidgetActionDescriptor) {
+    if ($event) {
+      $event.stopPropagation();
+    }
+    let entityId;
+    let entityName;
+    let entityLabel;
+    if (this.ctx.activeEntityInfo) {
+      entityId = this.ctx.activeEntityInfo.entityId;
+      entityName = this.ctx.activeEntityInfo.entityName;
+      entityLabel = this.ctx.activeEntityInfo.entityLabel;
+    }
+    this.ctx.actionsApi.handleWidgetAction($event, actionDescriptor, entityId, entityName, row, entityLabel);
+  }
+
+  public isActiveTab(index: number): boolean {
+    return index === this.sourceIndex;
+  }
+
+  private updateCurrentSourceAllData() {
+    this.sources[this.sourceIndex].timeseriesDatasource.allDataUpdated(this.data, this.latestData);
+  }
+
+  private updateCurrentSourceData() {
+    this.sources[this.sourceIndex].timeseriesDatasource.dataUpdated(this.data);
+  }
+
+  private updateCurrentSourceLatestData() {
+    this.sources[this.sourceIndex].timeseriesDatasource.latestDataUpdated(this.latestData);
+  }
+
+  private loadCurrentSourceRow() {
+    this.sources[this.sourceIndex].timeseriesDatasource.loadRows();
+    this.clearCache();
+  }
+
+  private clearCache() {
+    this.cellContentCache.length = 0;
+    this.cellStyleCache.length = 0;
+    this.rowStyleCache.length = 0;
+  }
+}
+
+class TimeseriesDatasource implements DataSource<TimeseriesRow> {
+
+  private rowsSubject = new BehaviorSubject<TimeseriesRow[]>([]);
+  private pageDataSubject = new BehaviorSubject<PageData<TimeseriesRow>>(emptyPageData<TimeseriesRow>());
+
+  private allRowsSubject = new BehaviorSubject<TimeseriesRow[]>([]);
+  private allRows$: Observable<Array<TimeseriesRow>> = this.allRowsSubject.asObservable();
+
+  public countCellButtonAction = 0;
+
+  private reserveSpaceForHiddenAction = true;
+  private cellButtonActions: TableCellButtonActionDescriptor[];
+  private usedShowCellActionFunction: boolean;
+  private inited = false;
+
+  constructor(
+    private source: TimeseriesTableSource,
+    private hideEmptyLines: boolean,
+    private dateFormatFilter: string,
+    private datePipe: DatePipe,
+    private widgetContext: WidgetContext
+  ) {
+    if (this.widgetContext.settings.reserveSpaceForHiddenAction) {
+      this.reserveSpaceForHiddenAction = coerceBooleanProperty(this.widgetContext.settings.reserveSpaceForHiddenAction);
+    }
+    this.source.timeseriesDatasource = this;
+  }
+
+  private init(): Observable<any> {
+    if (this.inited) {
+      return of(null);
+    }
+    return getTableCellButtonActions(this.widgetContext).pipe(
+      tap(actions => {
+        this.cellButtonActions = actions
+        this.usedShowCellActionFunction = this.cellButtonActions.some(action => action.useShowActionCellButtonFunction);
+        this.inited = true;
+      })
+    );
+  }
+
+  connect(collectionViewer: CollectionViewer): Observable<TimeseriesRow[] | ReadonlyArray<TimeseriesRow>> {
+    if (this.rowsSubject.isStopped) {
+      this.rowsSubject.isStopped = false;
+      this.pageDataSubject.isStopped = false;
+    }
+    return this.rowsSubject.asObservable();
+  }
+
+  disconnect(collectionViewer: CollectionViewer): void {
+    this.rowsSubject.complete();
+    this.pageDataSubject.complete();
+  }
+
+  loadRows() {
+    this.fetchRows(this.source.pageLink).pipe(
+      catchError(() => of(emptyPageData<TimeseriesRow>())),
+    ).subscribe(
+      (pageData) => {
+        this.rowsSubject.next(pageData.data);
+        this.pageDataSubject.next(pageData);
+      }
+    );
+  }
+
+  allDataUpdated(data: DatasourceData[], latestData: DatasourceData[]) {
+    this.source.rawData = data.slice(this.source.keyStartIndex, this.source.keyEndIndex);
+    this.source.latestRawData = latestData.slice(this.source.latestKeyStartIndex, this.source.latestKeyEndIndex);
+    this.updateSourceData();
+  }
+
+  dataUpdated(data: DatasourceData[]) {
+    this.source.rawData = data.slice(this.source.keyStartIndex, this.source.keyEndIndex);
+    this.updateSourceData();
+  }
+
+  latestDataUpdated(latestData: DatasourceData[]) {
+    this.source.latestRawData = latestData.slice(this.source.latestKeyStartIndex, this.source.latestKeyEndIndex);
+    this.updateSourceData();
+  }
+
+  private updateSourceData() {
+    this.convertData(this.source.rawData, this.source.latestRawData).subscribe((data) => {
+      this.source.data = data;
+      this.allRowsSubject.next(this.source.data);
+    });
+  }
+
+  public formatTimestamp(timestamp: number): string {
+    if (this.widgetContext?.settings?.useJalaliDate) {
+      // تبدیل به تاریخ جلالی
+      if(this.widgetContext?.settings?.showMilliseconds){
+        return moment(timestamp).format('jYYYY/jMM/jDD HH:mm:ss.SSS');
+      } else {
+        return moment(timestamp).format('jYYYY/jMM/jDD HH:mm:ss');
+      }
+    } else {
+      // تبدیل به تاریخ میلادی
+      if(this.widgetContext?.settings?.dateFormat){
+        // return moment(timestamp).format(this.widgetContext?.settings?.dateFormat?.format);
+        return this.datePipe.transform(timestamp, this.dateFormatFilter);
+      } else {
+        return moment(timestamp).format('YYYY/MM/DD HH:mm:ss');
+      }
+    }
+  }
+
+  private convertData(data: DatasourceData[], latestData: DatasourceData[]): Observable<TimeseriesRow[]> {
+    return this.init().pipe(
+      map(() => {
+        const rowsMap: {[timestamp: number]: TimeseriesRow} = {};
+        for (let d = 0; d < data.length; d++) {
+          const columnData = data[d].data;
+          columnData.forEach((cellData) => {
+            const timestamp = cellData[0];
+            let row = rowsMap[timestamp];
+            if (!row) {
+              row = {
+                // The original
+                // formattedTs: this.datePipe.transform(timestamp, this.dateFormatFilter)
+                
+                // Our fomatted timestamp based on useJalaliDate in widget setting
+                formattedTs: this.formatTimestamp(timestamp)
+              };
+              if (this.cellButtonActions.length) {
+                if (this.usedShowCellActionFunction) {
+                  const parsedData = formattedDataFormDatasourceData(data, undefined, timestamp);
+                  row.actionCellButtons = prepareTableCellButtonActions(this.widgetContext, this.cellButtonActions,
+                    parsedData[0], this.reserveSpaceForHiddenAction);
+                  row.hasActions = checkHasActions(row.actionCellButtons);
+                } else {
+                  row.hasActions = true;
+                  row.actionCellButtons = this.cellButtonActions;
+                }
+              }
+              row[0] = timestamp;
+              for (let c = 0; c < (data.length + latestData.length); c++) {
+                row[c + 1] = undefined;
+              }
+              rowsMap[timestamp] = row;
+            }
+            row[d + 1] = cellData[1];
+          });
+        }
+
+        let rows: TimeseriesRow[]  = [];
+        if (this.hideEmptyLines) {
+          for (const t of Object.keys(rowsMap)) {
+            let hideLine = true;
+            for (let c = 0; (c < data.length) && hideLine; c++) {
+              if (rowsMap[t][c + 1]) {
+                hideLine = false;
+              }
+            }
+            if (!hideLine) {
+              rows.push(rowsMap[t]);
+            }
+          }
+        } else {
+          rows = Object.keys(rowsMap).map(itm => rowsMap[itm]);
+        }
+        for (let d = 0; d < latestData.length; d++) {
+          const columnData = latestData[d].data;
+          if (columnData.length) {
+            const value = columnData[0][1];
+            rows.forEach((row) => {
+              row[data.length + d + 1] = value;
+            });
+          }
+        }
+        return rows;
+      })
+    );
+  }
+
+  isEmpty(): Observable<boolean> {
+    return this.rowsSubject.pipe(
+      map((rows) => !rows.length)
+    );
+  }
+
+  total(): Observable<number> {
+    return this.pageDataSubject.pipe(
+      map((pageData) => pageData.totalElements)
+    );
+  }
+
+  private fetchRows(pageLink: PageLink): Observable<PageData<TimeseriesRow>> {
+    return this.init().pipe(
+      switchMap(() => {
+        return this.allRows$.pipe(
+          map((data) => {
+            const fetchData = pageLink.filterData(data);
+            if (this.cellButtonActions.length) {
+              let maxCellButtonAction: number;
+              if (this.usedShowCellActionFunction && !this.reserveSpaceForHiddenAction) {
+                maxCellButtonAction = Math.max(...fetchData.data.map(tsRow => tsRow.actionCellButtons.length));
+              } else {
+                maxCellButtonAction = this.cellButtonActions.length;
+              }
+              this.countCellButtonAction = maxCellButtonAction;
+            }
+            return fetchData;
+          })
+        );
+      })
+    );
+  }
+}

--- a/ui-ngx/src/app/modules/home/components/widget/lib/settings/cards/persian-timeseries-table/persian-timeseries-table-key-settings.component.html
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/settings/cards/persian-timeseries-table/persian-timeseries-table-key-settings.component.html
@@ -1,0 +1,104 @@
+<!--
+
+    Copyright © 2016-2025 The Thingsboard Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<ng-container [formGroup]="timeseriesTableKeySettingsForm">
+  <div class="tb-form-panel">
+    <div class="tb-form-panel-title" translate>widgets.table.column-settings</div>
+    <div class="tb-form-row space-between">
+      <div>{{ 'widgets.table.default-column-visibility' | translate }}</div>
+      <mat-form-field class="medium-width" appearance="outline" subscriptSizing="dynamic">
+        <mat-select formControlName="defaultColumnVisibility">
+          <mat-option [value]="'visible'">
+            {{ 'widgets.table.column-visibility-visible' | translate }}
+          </mat-option>
+          <mat-option [value]="'hidden'">
+            {{ 'widgets.table.column-visibility-hidden' | translate }}
+          </mat-option>
+          <mat-option [value]="'hidden-mobile'">
+            {{ 'widgets.table.column-visibility-hidden-mobile' | translate }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+    </div>
+    <div class="tb-form-row space-between">
+      <div>{{ 'widgets.table.column-selection-to-display' | translate }}</div>
+      <mat-form-field class="medium-width" appearance="outline" subscriptSizing="dynamic">
+        <mat-select formControlName="columnSelectionToDisplay">
+          <mat-option [value]="'enabled'">
+            {{ 'widgets.table.column-selection-to-display-enabled' | translate }}
+          </mat-option>
+          <mat-option [value]="'disabled'">
+            {{ 'widgets.table.column-selection-to-display-disabled' | translate }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+    </div>
+    <div class="tb-form-row">
+      <mat-slide-toggle class="mat-slide"  formControlName="disableSorting">
+        {{ 'widgets.table.disable-sorting' | translate }}
+      </mat-slide-toggle>
+    </div>
+  </div>
+  <div class="tb-form-panel tb-slide-toggle">
+    <mat-expansion-panel class="tb-settings" [expanded]="timeseriesTableKeySettingsForm.get('useCellStyleFunction').value">
+      <mat-expansion-panel-header class="flex flex-row flex-wrap">
+        <mat-panel-title>
+          <mat-slide-toggle class="mat-slide flex items-stretch justify-center" formControlName="useCellStyleFunction" (click)="$event.stopPropagation()">
+            {{ 'widgets.table.use-cell-style-function' | translate }}
+          </mat-slide-toggle>
+        </mat-panel-title>
+        <mat-panel-description class="flex max-w-40% flex-full items-center justify-end xs:!hidden" translate>
+          widget-config.advanced-settings
+        </mat-panel-description>
+      </mat-expansion-panel-header>
+      <ng-template matExpansionPanelContent>
+        <tb-js-func required
+                    formControlName="cellStyleFunction"
+                    withModules
+                    [globalVariables]="functionScopeVariables"
+                    [functionArgs]="['value', 'rowData', 'ctx']"
+                    functionTitle="{{ 'widgets.table.cell-style-function' | translate }}"
+                    helpId="widget/lib/timeseries/cell_style_fn">
+        </tb-js-func>
+      </ng-template>
+    </mat-expansion-panel>
+  </div>
+  <div class="tb-form-panel tb-slide-toggle">
+    <mat-expansion-panel class="tb-settings" [expanded]="timeseriesTableKeySettingsForm.get('useCellContentFunction').value">
+      <mat-expansion-panel-header class="flex flex-row flex-wrap">
+        <mat-panel-title>
+          <mat-slide-toggle class="mat-slide flex items-stretch justify-center" formControlName="useCellContentFunction" (click)="$event.stopPropagation()">
+            {{ 'widgets.table.use-cell-content-function' | translate }}
+          </mat-slide-toggle>
+        </mat-panel-title>
+        <mat-panel-description class="flex max-w-40% flex-full items-center justify-end xs:!hidden" translate>
+          widget-config.advanced-settings
+        </mat-panel-description>
+      </mat-expansion-panel-header>
+      <ng-template matExpansionPanelContent>
+        <tb-js-func required
+                    formControlName="cellContentFunction"
+                    withModules
+                    [globalVariables]="functionScopeVariables"
+                    [functionArgs]="['value', 'rowData', 'ctx']"
+                    functionTitle="{{ 'widgets.table.cell-content-function' | translate }}"
+                    helpId="widget/lib/timeseries/cell_content_fn">
+        </tb-js-func>
+      </ng-template>
+    </mat-expansion-panel>
+  </div>
+</ng-container>

--- a/ui-ngx/src/app/modules/home/components/widget/lib/settings/cards/persian-timeseries-table/persian-timeseries-table-key-settings.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/settings/cards/persian-timeseries-table/persian-timeseries-table-key-settings.component.ts
@@ -1,0 +1,86 @@
+///
+/// Copyright © 2016-2025 The Thingsboard Authors
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+
+import { Component } from '@angular/core';
+import { WidgetSettings, WidgetSettingsComponent } from '@shared/models/widget.models';
+import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
+import { Store } from '@ngrx/store';
+import { AppState } from '@core/core.state';
+
+@Component({
+  selector: 'persian-timeseries-table-key-settings',
+  templateUrl: './persian-timeseries-table-key-settings.component.html',
+  styleUrls: ['./../../widget-settings.scss']
+})
+export class PersianTimeseriesTableKeySettingsComponent extends WidgetSettingsComponent {
+
+  timeseriesTableKeySettingsForm: UntypedFormGroup;
+
+  constructor(protected store: Store<AppState>,
+              private fb: UntypedFormBuilder) {
+    super(store);
+  }
+
+  protected settingsForm(): UntypedFormGroup {
+    return this.timeseriesTableKeySettingsForm;
+  }
+
+  protected defaultSettings(): WidgetSettings {
+    return {
+      useCellStyleFunction: false,
+      cellStyleFunction: '',
+      useCellContentFunction: false,
+      cellContentFunction: '',
+      defaultColumnVisibility: 'visible',
+      columnSelectionToDisplay: 'enabled',
+      disableSorting: false
+    };
+  }
+
+  protected onSettingsSet(settings: WidgetSettings) {
+    this.timeseriesTableKeySettingsForm = this.fb.group({
+      useCellStyleFunction: [settings.useCellStyleFunction, []],
+      cellStyleFunction: [settings.cellStyleFunction, [Validators.required]],
+      useCellContentFunction: [settings.useCellContentFunction, []],
+      cellContentFunction: [settings.cellContentFunction, [Validators.required]],
+      defaultColumnVisibility: [settings.defaultColumnVisibility, []],
+      columnSelectionToDisplay: [settings.columnSelectionToDisplay, []],
+      disableSorting: [settings.disableSorting, []]
+    });
+  }
+
+  protected validatorTriggers(): string[] {
+    return ['useCellStyleFunction', 'useCellContentFunction'];
+  }
+
+  protected updateValidators(emitEvent: boolean) {
+    const useCellStyleFunction: boolean = this.timeseriesTableKeySettingsForm.get('useCellStyleFunction').value;
+    const useCellContentFunction: boolean = this.timeseriesTableKeySettingsForm.get('useCellContentFunction').value;
+    if (useCellStyleFunction) {
+      this.timeseriesTableKeySettingsForm.get('cellStyleFunction').enable();
+    } else {
+      this.timeseriesTableKeySettingsForm.get('cellStyleFunction').disable();
+    }
+    if (useCellContentFunction) {
+      this.timeseriesTableKeySettingsForm.get('cellContentFunction').enable();
+    } else {
+      this.timeseriesTableKeySettingsForm.get('cellContentFunction').disable();
+    }
+    this.timeseriesTableKeySettingsForm.get('cellStyleFunction').updateValueAndValidity({emitEvent});
+    this.timeseriesTableKeySettingsForm.get('cellContentFunction').updateValueAndValidity({emitEvent});
+  }
+
+}

--- a/ui-ngx/src/app/modules/home/components/widget/lib/settings/cards/persian-timeseries-table/persian-timeseries-table-latest-key-settings.component.html
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/settings/cards/persian-timeseries-table/persian-timeseries-table-latest-key-settings.component.html
@@ -1,0 +1,114 @@
+<!--
+
+    Copyright © 2016-2025 The Thingsboard Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<ng-container [formGroup]="timeseriesTableLatestKeySettingsForm">
+  <div class="tb-form-panel">
+    <div class="tb-form-panel-title" translate>widgets.table.column-settings</div>
+    <mat-slide-toggle class="mat-slide" formControlName="show">
+      {{ 'widgets.table.show-latest-data-column' | translate }}
+    </mat-slide-toggle>
+    <div [class.!hidden]="!timeseriesTableLatestKeySettingsForm.get('show').value" class="tb-form-row space-between">
+      <div translate>widgets.table.latest-data-column-order</div>
+      <mat-form-field appearance="outline" class="number" subscriptSizing="dynamic">
+        <input matInput formControlName="order" type="number" step="1" placeholder="{{ 'widget-config.set' | translate }}">
+      </mat-form-field>
+    </div>
+    <div [class.!hidden]="!timeseriesTableLatestKeySettingsForm.get('show').value" class="tb-form-row space-between">
+      <div>{{ 'widgets.table.default-column-visibility' | translate }}</div>
+      <mat-form-field class="medium-width" appearance="outline" subscriptSizing="dynamic">
+        <mat-select formControlName="defaultColumnVisibility">
+          <mat-option [value]="'visible'">
+            {{ 'widgets.table.column-visibility-visible' | translate }}
+          </mat-option>
+          <mat-option [value]="'hidden'">
+            {{ 'widgets.table.column-visibility-hidden' | translate }}
+          </mat-option>
+          <mat-option [value]="'hidden-mobile'">
+            {{ 'widgets.table.column-visibility-hidden-mobile' | translate }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+    </div>
+    <div [class.!hidden]="!timeseriesTableLatestKeySettingsForm.get('show').value" class="tb-form-row space-between">
+      <div>{{ 'widgets.table.column-selection-to-display' | translate }}</div>
+      <mat-form-field class="medium-width" appearance="outline" subscriptSizing="dynamic">
+        <mat-select formControlName="columnSelectionToDisplay">
+          <mat-option [value]="'enabled'">
+            {{ 'widgets.table.column-selection-to-display-enabled' | translate }}
+          </mat-option>
+          <mat-option [value]="'disabled'">
+            {{ 'widgets.table.column-selection-to-display-disabled' | translate }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+    </div>
+    <div class="tb-form-row">
+      <mat-slide-toggle class="mat-slide"  formControlName="disableSorting">
+        {{ 'widgets.table.disable-sorting' | translate }}
+      </mat-slide-toggle>
+    </div>
+  </div>
+  <div [class.!hidden]="!timeseriesTableLatestKeySettingsForm.get('show').value" class="tb-form-panel tb-slide-toggle">
+    <mat-expansion-panel class="tb-settings" [expanded]="timeseriesTableLatestKeySettingsForm.get('useCellStyleFunction').value">
+      <mat-expansion-panel-header class="flex flex-row flex-wrap">
+        <mat-panel-title>
+          <mat-slide-toggle class="mat-slide flex items-stretch justify-center" formControlName="useCellStyleFunction" (click)="$event.stopPropagation()">
+            {{ 'widgets.table.use-cell-style-function' | translate }}
+          </mat-slide-toggle>
+        </mat-panel-title>
+        <mat-panel-description class="flex max-w-40% flex-full items-center justify-end xs:!hidden" translate>
+          widget-config.advanced-settings
+        </mat-panel-description>
+      </mat-expansion-panel-header>
+      <ng-template matExpansionPanelContent>
+        <tb-js-func required
+                    formControlName="cellStyleFunction"
+                    withModules
+                    [globalVariables]="functionScopeVariables"
+                    [functionArgs]="['value', 'rowData', 'ctx']"
+                    functionTitle="{{ 'widgets.table.cell-style-function' | translate }}"
+                    helpId="widget/lib/timeseries/cell_style_fn">
+        </tb-js-func>
+      </ng-template>
+    </mat-expansion-panel>
+  </div>
+  <div [class.!hidden]="!timeseriesTableLatestKeySettingsForm.get('show').value" class="tb-form-panel tb-slide-toggle">
+    <mat-expansion-panel class="tb-settings" [expanded]="timeseriesTableLatestKeySettingsForm.get('useCellContentFunction').value">
+      <mat-expansion-panel-header class="flex flex-row flex-wrap">
+        <mat-panel-title>
+          <mat-slide-toggle class="mat-slide flex items-stretch justify-center" formControlName="useCellContentFunction" (click)="$event.stopPropagation()">
+            {{ 'widgets.table.use-cell-content-function' | translate }}
+          </mat-slide-toggle>
+        </mat-panel-title>
+        <mat-panel-description class="flex max-w-40% flex-full items-center justify-end xs:!hidden" translate>
+          widget-config.advanced-settings
+        </mat-panel-description>
+      </mat-expansion-panel-header>
+      <ng-template matExpansionPanelContent>
+        <tb-js-func required
+                    formControlName="cellContentFunction"
+                    withModules
+                    [globalVariables]="functionScopeVariables"
+                    [functionArgs]="['value', 'rowData', 'ctx']"
+                    functionTitle="{{ 'widgets.table.cell-content-function' | translate }}"
+                    helpId="widget/lib/timeseries/cell_content_fn">
+        </tb-js-func>
+      </ng-template>
+    </mat-expansion-panel>
+  </div>
+</ng-container>
+

--- a/ui-ngx/src/app/modules/home/components/widget/lib/settings/cards/persian-timeseries-table/persian-timeseries-table-latest-key-settings.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/settings/cards/persian-timeseries-table/persian-timeseries-table-latest-key-settings.component.ts
@@ -1,0 +1,102 @@
+///
+/// Copyright © 2016-2025 The Thingsboard Authors
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///     http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+
+import { Component } from '@angular/core';
+import { WidgetSettings, WidgetSettingsComponent } from '@shared/models/widget.models';
+import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
+import { Store } from '@ngrx/store';
+import { AppState } from '@core/core.state';
+
+@Component({
+  selector: 'persian-timeseries-table-latest-key-settings',
+  templateUrl: './persian-timeseries-table-latest-key-settings.component.html',
+  styleUrls: ['./../../widget-settings.scss']
+})
+export class PersianTimeseriesTableLatestKeySettingsComponent extends WidgetSettingsComponent {
+
+  timeseriesTableLatestKeySettingsForm: UntypedFormGroup;
+
+  constructor(protected store: Store<AppState>,
+              private fb: UntypedFormBuilder) {
+    super(store);
+  }
+
+  protected settingsForm(): UntypedFormGroup {
+    return this.timeseriesTableLatestKeySettingsForm;
+  }
+
+  protected defaultSettings(): WidgetSettings {
+    return {
+      show: true,
+      useCellStyleFunction: false,
+      cellStyleFunction: '',
+      useCellContentFunction: false,
+      cellContentFunction: '',
+      defaultColumnVisibility: 'visible',
+      columnSelectionToDisplay: 'enabled',
+      disableSorting: false
+    };
+  }
+
+  protected onSettingsSet(settings: WidgetSettings) {
+    this.timeseriesTableLatestKeySettingsForm = this.fb.group({
+      show: [settings.show, []],
+      order: [settings.order, []],
+      useCellStyleFunction: [settings.useCellStyleFunction, []],
+      cellStyleFunction: [settings.cellStyleFunction, [Validators.required]],
+      useCellContentFunction: [settings.useCellContentFunction, []],
+      cellContentFunction: [settings.cellContentFunction, [Validators.required]],
+      defaultColumnVisibility: [settings.defaultColumnVisibility, []],
+      columnSelectionToDisplay: [settings.columnSelectionToDisplay, []],
+      disableSorting: [settings.disableSorting, []]
+    });
+  }
+
+  protected validatorTriggers(): string[] {
+    return ['show', 'useCellStyleFunction', 'useCellContentFunction'];
+  }
+
+  protected updateValidators(emitEvent: boolean) {
+    const show: boolean = this.timeseriesTableLatestKeySettingsForm.get('show').value;
+    if (show) {
+      this.timeseriesTableLatestKeySettingsForm.get('order').enable();
+      this.timeseriesTableLatestKeySettingsForm.get('useCellStyleFunction').enable({emitEvent: false});
+      this.timeseriesTableLatestKeySettingsForm.get('useCellContentFunction').enable({emitEvent: false});
+      const useCellStyleFunction: boolean = this.timeseriesTableLatestKeySettingsForm.get('useCellStyleFunction').value;
+      const useCellContentFunction: boolean = this.timeseriesTableLatestKeySettingsForm.get('useCellContentFunction').value;
+      if (useCellStyleFunction) {
+        this.timeseriesTableLatestKeySettingsForm.get('cellStyleFunction').enable();
+      } else {
+        this.timeseriesTableLatestKeySettingsForm.get('cellStyleFunction').disable();
+      }
+      if (useCellContentFunction) {
+        this.timeseriesTableLatestKeySettingsForm.get('cellContentFunction').enable();
+      } else {
+        this.timeseriesTableLatestKeySettingsForm.get('cellContentFunction').disable();
+      }
+    } else {
+      this.timeseriesTableLatestKeySettingsForm.get('order').disable();
+      this.timeseriesTableLatestKeySettingsForm.get('useCellStyleFunction').disable({emitEvent: false});
+      this.timeseriesTableLatestKeySettingsForm.get('cellStyleFunction').disable();
+      this.timeseriesTableLatestKeySettingsForm.get('useCellContentFunction').disable({emitEvent: false});
+      this.timeseriesTableLatestKeySettingsForm.get('cellContentFunction').disable();
+    }
+    this.timeseriesTableLatestKeySettingsForm.get('order').updateValueAndValidity({emitEvent});
+    this.timeseriesTableLatestKeySettingsForm.get('cellStyleFunction').updateValueAndValidity({emitEvent});
+    this.timeseriesTableLatestKeySettingsForm.get('cellContentFunction').updateValueAndValidity({emitEvent});
+  }
+
+}

--- a/ui-ngx/src/app/modules/home/components/widget/lib/settings/cards/persian-timeseries-table/persian-timeseries-table-widget-settings.component.html
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/settings/cards/persian-timeseries-table/persian-timeseries-table-widget-settings.component.html
@@ -1,0 +1,134 @@
+<ng-container [formGroup]="timeseriesTableWidgetSettingsForm">
+  <div class="tb-form-panel">
+    <div class="tb-form-panel-title" translate>widgets.table.table-header</div>
+    <mat-slide-toggle class="mat-slide"  formControlName="enableStickyHeader">
+      {{ 'widgets.table.enable-sticky-header' | translate }}
+    </mat-slide-toggle>
+    <mat-slide-toggle class="mat-slide"  formControlName="enableSearch">
+      {{ 'widgets.table.enable-search' | translate }}
+    </mat-slide-toggle>
+    <mat-slide-toggle class="mat-slide"  formControlName="enableSelectColumnDisplay">
+      {{ 'widgets.table.enable-select-column-display' | translate }}
+    </mat-slide-toggle>
+  </div>
+  <div class="tb-form-panel">
+    <div class="tb-form-panel-title" translate>widgets.table.columns</div>
+
+    <div  class="tb-form-row column-xs">
+      <mat-slide-toggle class="mat-slide fixed-title-width" formControlName="showTimestamp">
+        {{ 'widgets.table.display-timestamp' | translate }}
+      </mat-slide-toggle>
+      <tb-date-format-select class="flex-1" excludeLastUpdateAgo formControlName="dateFormat"></tb-date-format-select>
+      <mat-slide-toggle class="mat-slide fixed-title-width" formControlName="useJalaliDate">
+        <!-- نمایش تاریخ به صورت شمسی -->
+        {{ 'widgets.table.use-jalali-date' | translate }}
+      </mat-slide-toggle>
+    </div>
+
+    <mat-slide-toggle class="mat-slide"  formControlName="enableStickyAction">
+      {{ 'widgets.table.enable-sticky-action' | translate }}
+    </mat-slide-toggle>
+    <mat-slide-toggle class="mat-slide"  formControlName="showCellActionsMenu">
+      {{ 'widgets.table.show-cell-actions-menu-mobile' | translate }}
+    </mat-slide-toggle>
+    <mat-form-field class="flex-1" subscriptSizing="dynamic">
+      <mat-label translate>widgets.table.hidden-cell-button-display-mode</mat-label>
+      <mat-select formControlName="reserveSpaceForHiddenAction">
+        <mat-option [value]="'true'">
+          {{ 'widgets.table.show-empty-space-hidden-action' | translate }}
+        </mat-option>
+        <mat-option [value]="'false'">
+          {{ 'widgets.table.dont-reserve-space-hidden-action' | translate }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+  </div>
+  <div class="tb-form-panel">
+    <div class="tb-form-panel-title" translate>widgets.table.pagination</div>
+    <mat-slide-toggle class="mat-slide"  formControlName="displayPagination">
+      {{ 'widgets.table.display-pagination' | translate }}
+    </mat-slide-toggle>
+    <div class="tb-form-row space-between column-xs">
+      <div class="fixed-title-width !min-w-30">{{ 'widgets.table.page-step-settings' | translate }}</div>
+      <div class="flex flex-row items-center justify-start gap-2">
+        <div class="tb-small-label" translate>widgets.table.page-step-increment</div>
+        <mat-form-field appearance="outline" class="number" subscriptSizing="dynamic">
+          <input matInput formControlName="pageStepIncrement" type="number" min="1" step="1" required
+                 placeholder="{{ 'widget-config.set' | translate }}">
+          <mat-icon matSuffix
+                    matTooltipPosition="above"
+                    matTooltipClass="tb-error-tooltip"
+                    [matTooltip]="(timeseriesTableWidgetSettingsForm.get('pageStepIncrement').hasError('required')
+                                     ? 'widgets.value-source.value-required'
+                                     : 'widgets.table.page-step-increment-format-message') | translate"
+                    *ngIf="timeseriesTableWidgetSettingsForm.get('pageStepIncrement').invalid
+                    && timeseriesTableWidgetSettingsForm.get('pageStepIncrement').touched"
+                    class="tb-error">
+            warning
+          </mat-icon>
+        </mat-form-field>
+        <mat-divider vertical class="xs:hidden"></mat-divider>
+        <div class="tb-small-label" translate>widgets.table.page-step-count</div>
+        <mat-form-field appearance="outline" class="number" subscriptSizing="dynamic">
+          <input matInput formControlName="pageStepCount" type="number" min="1" max="100" step="1" required
+                 placeholder="{{ 'widget-config.set' | translate }}">
+          <mat-icon matSuffix
+                    matTooltipPosition="above"
+                    matTooltipClass="tb-error-tooltip"
+                    [matTooltip]="(timeseriesTableWidgetSettingsForm.get('pageStepCount').hasError('required')
+                                     ? 'widgets.value-source.value-required'
+                                     : 'widgets.table.page-step-count-format-message') | translate"
+                    *ngIf="timeseriesTableWidgetSettingsForm.get('pageStepCount').invalid
+                    && timeseriesTableWidgetSettingsForm.get('pageStepCount').touched"
+                    class="tb-error">
+            warning
+          </mat-icon>
+        </mat-form-field>
+      </div>
+    </div>
+    <div class="tb-form-row space-between column-xs">
+      <div translate>widgets.table.default-page-size</div>
+      <mat-form-field appearance="outline" subscriptSizing="dynamic">
+        <mat-select formControlName="defaultPageSize" placeholder="{{ 'widget-config.set' | translate }}">
+          <mat-option *ngFor="let size of pageStepSizeValues" [value]="size">
+            {{ size }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+    </div>
+  </div>
+  <div class="tb-form-panel">
+    <div class="tb-form-panel-title" translate>widgets.table.table-tabs</div>
+    <mat-slide-toggle class="mat-slide" formControlName="useEntityLabel">
+      {{ 'widgets.table.use-entity-label-tab-name' | translate }}
+    </mat-slide-toggle>
+  </div>
+  <div class="tb-form-panel tb-slide-toggle">
+    <div class="tb-form-panel-title" style="padding-bottom: 16px;" translate>widgets.table.rows</div>
+    <mat-slide-toggle class="mat-slide" style="padding-left: 16px;" formControlName="hideEmptyLines">
+      {{ 'widgets.table.hide-empty-lines' | translate }}
+    </mat-slide-toggle>
+    <mat-expansion-panel class="tb-settings" [expanded]="timeseriesTableWidgetSettingsForm.get('useRowStyleFunction').value">
+      <mat-expansion-panel-header class="flex flex-row flex-wrap">
+        <mat-panel-title>
+          <mat-slide-toggle class="mat-slide flex items-stretch justify-center" formControlName="useRowStyleFunction" (click)="$event.stopPropagation()">
+            {{ 'widgets.table.use-row-style-function' | translate }}
+          </mat-slide-toggle>
+        </mat-panel-title>
+        <mat-panel-description class="flex max-w-40% flex-full items-center justify-end xs:!hidden" translate>
+          widget-config.advanced-settings
+        </mat-panel-description>
+      </mat-expansion-panel-header>
+      <ng-template matExpansionPanelContent>
+        <tb-js-func required
+                    formControlName="rowStyleFunction"
+                    withModules
+                    [globalVariables]="functionScopeVariables"
+                    [functionArgs]="['rowData', 'ctx']"
+                    functionTitle="{{ 'widgets.table.row-style-function' | translate }}"
+                    helpId="widget/lib/timeseries/row_style_fn">
+        </tb-js-func>
+      </ng-template>
+    </mat-expansion-panel>
+  </div>
+</ng-container>

--- a/ui-ngx/src/app/modules/home/components/widget/lib/settings/cards/persian-timeseries-table/persian-timeseries-table-widget-settings.component.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/settings/cards/persian-timeseries-table/persian-timeseries-table-widget-settings.component.ts
@@ -1,0 +1,115 @@
+import { Component } from '@angular/core';
+import { WidgetSettings, WidgetSettingsComponent } from '@shared/models/widget.models';
+import { UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
+import { Store } from '@ngrx/store';
+import { AppState } from '@core/core.state';
+import { buildPageStepSizeValues } from '@home/components/widget/lib/table-widget.models';
+
+@Component({
+  selector: 'persian-timeseries-table-widget-settings',
+  templateUrl: './persian-timeseries-table-widget-settings.component.html',
+  styleUrls: ['./../../widget-settings.scss']
+})
+export class PersianTimeseriesTableWidgetSettingsComponent extends WidgetSettingsComponent {
+
+  timeseriesTableWidgetSettingsForm: UntypedFormGroup;
+  pageStepSizeValues = [];
+
+  constructor(protected store: Store<AppState>,
+              private fb: UntypedFormBuilder) {
+    super(store);
+  }
+
+  protected settingsForm(): UntypedFormGroup {
+    return this.timeseriesTableWidgetSettingsForm;
+  }
+
+  protected defaultSettings(): WidgetSettings {
+    return {
+      enableSearch: true,
+      enableSelectColumnDisplay: true,
+      enableStickyHeader: true,
+      enableStickyAction: true,
+      showCellActionsMenu: true,
+      reserveSpaceForHiddenAction: 'true',
+      showTimestamp: true,
+      useJalaliDate: true,
+      dateFormat: {format: 'yyyy-MM-dd HH:mm:ss'},
+      displayPagination: true,
+      useEntityLabel: false,
+      defaultPageSize: 10,
+      pageStepIncrement: null,
+      pageStepCount: 3,
+      hideEmptyLines: false,
+      disableStickyHeader: false,
+      useRowStyleFunction: false,
+      rowStyleFunction: ''
+    };
+  }
+
+  protected prepareInputSettings(settings: WidgetSettings): WidgetSettings {
+    settings.pageStepIncrement = settings.pageStepIncrement ?? settings.defaultPageSize;
+    this.pageStepSizeValues = buildPageStepSizeValues(settings.pageStepCount, settings.pageStepIncrement);
+    return settings;
+  }
+
+  protected onSettingsSet(settings: WidgetSettings) {
+    // For backward compatibility
+    const dateFormat = settings.dateFormat;
+    if (settings?.showMilliseconds) {
+      dateFormat.format = 'yyyy-MM-dd HH:mm:ss.SSS';
+    }
+
+    this.timeseriesTableWidgetSettingsForm = this.fb.group({
+      enableSearch: [settings.enableSearch, []],
+      enableSelectColumnDisplay: [settings.enableSelectColumnDisplay, []],
+      enableStickyHeader: [settings.enableStickyHeader, []],
+      enableStickyAction: [settings.enableStickyAction, []],
+      showCellActionsMenu: [settings.showCellActionsMenu, []],
+      reserveSpaceForHiddenAction: [settings.reserveSpaceForHiddenAction, []],
+      showTimestamp: [settings.showTimestamp, []],
+      useJalaliDate: [settings.useJalaliDate, []],
+      dateFormat: [dateFormat, []],
+      displayPagination: [settings.displayPagination, []],
+      useEntityLabel: [settings.useEntityLabel, []],
+      defaultPageSize: [settings.defaultPageSize, [Validators.min(1)]],
+      pageStepCount: [settings.pageStepCount ?? 3, [Validators.min(1), Validators.max(100),
+        Validators.required, Validators.pattern(/^\d*$/)]],
+      pageStepIncrement: [settings.pageStepIncrement, [Validators.min(1), Validators.required, Validators.pattern(/^\d*$/)]],
+      hideEmptyLines: [settings.hideEmptyLines, []],
+      disableStickyHeader: [settings.disableStickyHeader, []],
+      useRowStyleFunction: [settings.useRowStyleFunction, []],
+      rowStyleFunction: [settings.rowStyleFunction, [Validators.required]]
+    });
+  }
+
+  protected validatorTriggers(): string[] {
+    return ['useRowStyleFunction', 'displayPagination', 'pageStepCount', 'pageStepIncrement'];
+  }
+
+  protected updateValidators(emitEvent: boolean, trigger: string) {
+    if (trigger === 'pageStepCount' || trigger === 'pageStepIncrement') {
+      this.timeseriesTableWidgetSettingsForm.get('defaultPageSize').reset();
+      this.pageStepSizeValues = buildPageStepSizeValues(this.timeseriesTableWidgetSettingsForm.get('pageStepCount').value,
+        this.timeseriesTableWidgetSettingsForm.get('pageStepIncrement').value);
+      return;
+    }
+    const useRowStyleFunction: boolean = this.timeseriesTableWidgetSettingsForm.get('useRowStyleFunction').value;
+    const displayPagination: boolean = this.timeseriesTableWidgetSettingsForm.get('displayPagination').value;
+    if (useRowStyleFunction) {
+      this.timeseriesTableWidgetSettingsForm.get('rowStyleFunction').enable({emitEvent});
+    } else {
+      this.timeseriesTableWidgetSettingsForm.get('rowStyleFunction').disable({emitEvent});
+    }
+    if (displayPagination) {
+      this.timeseriesTableWidgetSettingsForm.get('defaultPageSize').enable({emitEvent});
+      this.timeseriesTableWidgetSettingsForm.get('pageStepCount').enable({emitEvent: false});
+      this.timeseriesTableWidgetSettingsForm.get('pageStepIncrement').enable({emitEvent: false});
+    } else {
+      this.timeseriesTableWidgetSettingsForm.get('defaultPageSize').disable({emitEvent});
+      this.timeseriesTableWidgetSettingsForm.get('pageStepCount').disable({emitEvent: false});
+      this.timeseriesTableWidgetSettingsForm.get('pageStepIncrement').disable({emitEvent: false});
+    }
+  }
+
+}

--- a/ui-ngx/src/app/modules/home/components/widget/lib/settings/widget-settings.module.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/lib/settings/widget-settings.module.ts
@@ -31,6 +31,17 @@ import {
 import {
   TimeseriesTableLatestKeySettingsComponent
 } from '@home/components/widget/lib/settings/cards/timeseries-table-latest-key-settings.component';
+
+import {
+  PersianTimeseriesTableWidgetSettingsComponent
+} from '@home/components/widget/lib/settings/cards/persian-timeseries-table/persian-timeseries-table-widget-settings.component';
+import {
+  PersianTimeseriesTableKeySettingsComponent
+} from '@home/components/widget/lib/settings/cards/persian-timeseries-table/persian-timeseries-table-key-settings.component';
+import {
+  PersianTimeseriesTableLatestKeySettingsComponent
+} from '@home/components/widget/lib/settings/cards/persian-timeseries-table/persian-timeseries-table-latest-key-settings.component';
+
 import {
   MarkdownWidgetSettingsComponent
 } from '@home/components/widget/lib/settings/cards/markdown-widget-settings.component';
@@ -383,6 +394,9 @@ import { MapWidgetSettingsComponent } from '@home/components/widget/lib/settings
     TimeseriesTableWidgetSettingsComponent,
     TimeseriesTableKeySettingsComponent,
     TimeseriesTableLatestKeySettingsComponent,
+    PersianTimeseriesTableWidgetSettingsComponent,
+    PersianTimeseriesTableKeySettingsComponent,
+    PersianTimeseriesTableLatestKeySettingsComponent,
     MarkdownWidgetSettingsComponent,
     LabelWidgetLabelComponent,
     LabelWidgetSettingsComponent,
@@ -522,6 +536,9 @@ import { MapWidgetSettingsComponent } from '@home/components/widget/lib/settings
     TimeseriesTableWidgetSettingsComponent,
     TimeseriesTableKeySettingsComponent,
     TimeseriesTableLatestKeySettingsComponent,
+    PersianTimeseriesTableWidgetSettingsComponent,
+    PersianTimeseriesTableKeySettingsComponent,
+    PersianTimeseriesTableLatestKeySettingsComponent,
     MarkdownWidgetSettingsComponent,
     LabelWidgetLabelComponent,
     LabelWidgetSettingsComponent,

--- a/ui-ngx/src/app/modules/home/components/widget/widget-components.module.ts
+++ b/ui-ngx/src/app/modules/home/components/widget/widget-components.module.ts
@@ -22,6 +22,7 @@ import { DisplayColumnsPanelComponent } from '@home/components/widget/lib/displa
 import { AlarmsTableWidgetComponent } from '@home/components/widget/lib/alarm/alarms-table-widget.component';
 import { SharedHomeComponentsModule } from '@home/components/shared-home-components.module';
 import { TimeseriesTableWidgetComponent } from '@home/components/widget/lib/timeseries-table-widget.component';
+import { PersianTimeseriesTableWidgetComponent } from '@home/components/widget/lib/persian-timeseries-table/persian-timeseries-table-widget.component';
 import {
   EntitiesHierarchyWidgetComponent
 } from '@home/components/widget/lib/entity/entities-hierarchy-widget.component';
@@ -101,6 +102,7 @@ import { MapTimelinePanelComponent } from '@home/components/widget/lib/maps/pane
     EntitiesTableWidgetComponent,
     AlarmsTableWidgetComponent,
     TimeseriesTableWidgetComponent,
+    PersianTimeseriesTableWidgetComponent,
     EntitiesHierarchyWidgetComponent,
     EdgesOverviewWidgetComponent,
     DateRangeNavigatorWidgetComponent,
@@ -166,6 +168,7 @@ import { MapTimelinePanelComponent } from '@home/components/widget/lib/maps/pane
     EntitiesTableWidgetComponent,
     AlarmsTableWidgetComponent,
     TimeseriesTableWidgetComponent,
+    PersianTimeseriesTableWidgetComponent,
     EntitiesHierarchyWidgetComponent,
     EdgesOverviewWidgetComponent,
     RpcWidgetsModule,

--- a/ui-ngx/src/assets/locale/locale.constant-en_US.json
+++ b/ui-ngx/src/assets/locale/locale.constant-en_US.json
@@ -8987,7 +8987,8 @@
             "alarm-column-error": "At least one alarm column should be specified",
             "table-tabs": "Table tabs",
             "show-cell-actions-menu-mobile": "Show cell actions dropdown menu in mobile mode",
-            "disable-sorting": "Disable sorting"
+            "disable-sorting": "Disable sorting",
+            "use-jalali-date": "Use jalali date"
         },
         "latest-chart": {
             "total": "Total",

--- a/ui-ngx/yarn.lock
+++ b/ui-ngx/yarn.lock
@@ -6447,6 +6447,11 @@ jackspeak@^3.1.2:
   optionalDependencies:
     "@pkgjs/parseargs" "^0.11.0"
 
+jalaali-js@^1.2.7:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/jalaali-js/-/jalaali-js-1.2.8.tgz#dfc80398a0c4b4182f3eb883363b3b621e7a3878"
+  integrity sha512-Jl/EwY84JwjW2wsWqeU4pNd22VNQ7EkjI36bDuLw31wH98WQW4fPjD0+mG7cdCK+Y8D6s9R3zLiQ3LaKu6bD8A==
+
 jest-worker@^27.4.5:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.5.1.tgz#8d146f0900e8973b106b6f73cc1e9a8cb86f8db0"
@@ -7268,10 +7273,26 @@ mlly@^1.4.2, mlly@^1.7.1:
     pkg-types "^1.1.1"
     ufo "^1.5.3"
 
+moment-jalaali@^0.10.4:
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/moment-jalaali/-/moment-jalaali-0.10.4.tgz#8ca2c1651e3310be947049a1013acf9025cecfd6"
+  integrity sha512-/eD0HeyvATznb5iE0G1BHjKRZAFEpJ9ZNUkcHwXhNgt1WJJVVzHD7+uDmqzZWVFLdbGme2gvIXKb3ezDYOXcZA==
+  dependencies:
+    jalaali-js "^1.2.7"
+    moment "^2.29.4"
+    moment-timezone "^0.5.46"
+
 moment-timezone@^0.5.45:
   version "0.5.46"
   resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.46.tgz#a21aa6392b3c6b3ed916cd5e95858a28d893704a"
   integrity sha512-ZXm9b36esbe7OmdABqIWJuBBiLLwAjrN7CE+7sYdCCx82Nabt1wHDj8TVseS59QIlfFPbOoiBPm6ca9BioG4hw==
+  dependencies:
+    moment "^2.29.4"
+
+moment-timezone@^0.5.46:
+  version "0.5.48"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.48.tgz#111727bb274734a518ae154b5ca589283f058967"
+  integrity sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==
   dependencies:
     moment "^2.29.4"
 


### PR DESCRIPTION
Introduces a new Persian timeseries table widget component with support for Jalali (Persian) date formatting using moment-jalaali. Adds all related components, settings panels, and styles, updates package.json to include moment-jalaali, and registers the new widget in the module. Also updates locale constants for internationalization.